### PR TITLE
Fix IPC client timeout to match hooks.json (1 hour)

### DIFF
--- a/plugins/claude-afk/scripts/daemon/ipc.js
+++ b/plugins/claude-afk/scripts/daemon/ipc.js
@@ -10,8 +10,8 @@ const net = require('net');
 const xpipe = require('xpipe');
 const crypto = require('crypto');
 
-// Default timeout for client requests (5 minutes - matches permission timeout)
-const DEFAULT_TIMEOUT = 300000;
+// Default timeout for client requests (1 hour - matches hooks.json timeout)
+const DEFAULT_TIMEOUT = 3600000;
 
 /**
  * Create an IPC server that listens on a named pipe

--- a/plugins/claude-afk/scripts/daemon/ipc.test.js
+++ b/plugins/claude-afk/scripts/daemon/ipc.test.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-const { createIPCServer, createIPCClient, getDefaultPipePath } = require('./ipc.js');
+const { createIPCServer, createIPCClient, getDefaultPipePath, DEFAULT_TIMEOUT } = require('./ipc.js');
 
 describe('IPC communication', () => {
   let tempDir;
@@ -191,5 +191,19 @@ describe('IPC communication', () => {
     } else {
       assert.strictEqual(pipePath, '/tmp/claude-afk.sock');
     }
+  });
+
+  it('DEFAULT_TIMEOUT matches hooks.json timeout (1 hour)', () => {
+    // hooks.json specifies timeout: 3600 (seconds) for PermissionRequest and Stop hooks
+    // The IPC client DEFAULT_TIMEOUT must match this to avoid premature timeouts
+    // See: hooks/hooks.json lines 20 and 30
+    const HOOKS_TIMEOUT_SECONDS = 3600;
+    const EXPECTED_TIMEOUT_MS = HOOKS_TIMEOUT_SECONDS * 1000; // 3600000ms = 1 hour
+
+    assert.strictEqual(
+      DEFAULT_TIMEOUT,
+      EXPECTED_TIMEOUT_MS,
+      `DEFAULT_TIMEOUT (${DEFAULT_TIMEOUT}ms) should match hooks.json timeout (${EXPECTED_TIMEOUT_MS}ms / ${HOOKS_TIMEOUT_SECONDS}s)`
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Fix `DEFAULT_TIMEOUT` in IPC client from 300000ms (5 min) to 3600000ms (1 hour)
- Add regression test to ensure timeout value matches hooks.json configuration

## Problem

The IPC client was timing out after 5 minutes, but hooks.json specifies a 1-hour timeout. This caused Telegram notifications to fail prematurely when users took longer than 5 minutes to respond, logging "Request timeout after 300000ms" errors.

## Test plan

- [x] Added test: `DEFAULT_TIMEOUT matches hooks.json timeout (1 hour)`
- [x] Verified test fails before fix (RED)
- [x] Verified test passes after fix (GREEN)
- [x] Full test suite passes (190 tests)

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)