### PR TITLE
Instruct Claude to avoid AskUserQuestion while AFK

### DIFF
--- a/plugins/claude-afk/scripts/cli.js
+++ b/plugins/claude-afk/scripts/cli.js
@@ -54,8 +54,18 @@ function formatStatusOutput(status, currentSessionId) {
  * Format enable success output
  */
 function formatEnableOutput(sessionId, unreliable) {
-  let output = `AFK mode enabled for session ${sessionId.substring(0, 8)}...\n`;
-  output += 'You will receive Telegram notifications for permission requests.\n';
+  let output = `AFK mode enabled for session ${sessionId.substring(0, 8)}...\n\n`;
+
+  output += `You will receive Telegram notifications when:\n`;
+  output += `  - Claude needs permission approvals for tool usage\n`;
+  output += `  - Tasks are completed\n\n`;
+
+  output += `Reply "yes" or "no" directly to Telegram messages to respond.\n\n`;
+
+  output += `To disable AFK mode later, use /claude-afk:disable.\n\n`;
+
+  // Instruction for Claude about question format
+  output += `[For Claude: Avoid using AskUserQuestion tool while AFK - ask questions in narrative form instead.]\n`;
 
   if (unreliable) {
     output += '\nWarning: Using unreliable terminal ID (PID-based fallback).\n';


### PR DESCRIPTION
## Summary

- Add instruction in enable output telling Claude to avoid `AskUserQuestion` tool while AFK
- Claude should ask questions in narrative form instead, which gets captured by the Stop hook

## Problem

The `AskUserQuestion` tool presents multiple-choice UI that stalls AFK sessions. There's no hook to intercept it, and the `Notification` hook (`idle_prompt`) only fires after 60s and can't inject responses.

## Solution

A simple instruction in the enable output:
```
[For Claude: Avoid using AskUserQuestion tool while AFK - ask questions in narrative form instead.]
```

Narrative questions appear in the transcript and get captured by the Stop hook, allowing users to respond via Telegram.

## Test plan

- [x] Existing `formatEnableOutput` tests pass
- [x] Output clearly distinguishes user instructions from Claude instructions

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)